### PR TITLE
아이템 데이터 기반 렌더링으로 재편성

### DIFF
--- a/index.html
+++ b/index.html
@@ -652,532 +652,13 @@
     </div>
     <div class="item-tab-panels">
       <div class="item-list-content item-tab-panel active" role="tabpanel" data-tab-panel="weapon">
-
-      <!-- Weapon Items -->
-      <div class="item green" id="item-무기기름칠" data-name="무기 기름칠" data-price="1000" data-wp="0" data-as="5">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">무기 기름칠 (1,000)<br>공속+5%</span>
-      </div>
-      <div class="item green" id="item-보정기" data-name="보정기" data-price="1000" data-wp="5" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">보정기 (1,000)<br>무공+5%</span>
-      </div>
-      <div class="item blue" id="item-부품시장발사핀" data-name="부품 시장 발사 핀" data-price="3750" data-wp="0" data-as="10">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">부품 시장 발사 핀 (3,750)<br>공속+10%</span>
-      </div>
-      <div class="item blue" id="item-고급나노생물학" data-name="고급 나노생물학" data-price="4000" data-wp="5" data-as="10">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">고급 나노생물학 (4,000)<br>무공+5%, 공속+10%</span>
-      </div>
-      <div class="item blue" id="item-공중기동기" data-name="공중 기동기" data-price="4000" data-wp="5" data-as="10" data-fixed-only="true">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">공중 기동기 (4,000)<br>무공+5%, 공속+10%(고정 전용)</span>
-      </div>
-      <div class="item blue" id="item-꽉채운잔" data-name="꽉 채운 잔" data-price="4500" data-wp="0" data-as="5">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">꽉 채운 잔 (4,500)<br>공속+5%</span>
-      </div>
-      <div class="item blue" id="item-차가운냉각수" data-name="차가운 냉각수" data-price="5500" data-wp="10" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">차가운 냉각수 (5,500)<br>무공+10%</span>
-      </div>
-      <div class="item blue" id="item-탈론개조모듈" data-name="탈론 개조 모듈" data-price="6000" data-wp="15" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">탈론 개조 모듈 (6,000)<br>무공+15%</span>
-      </div>
-      <div class="item purple" id="item-공중조난자" data-name="공중 조난자" data-price="9000" data-wp="0" data-as="10">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">공중 조난자 (9,000)<br>공속+10%</span>
-      </div>
-      <div class="item purple" id="item-코드브레이커" data-name="코드브레이커" data-price="9000" data-wp="15" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">코드브레이커 (9,000)<br>무공+15%</span>
-      </div>
-      <div class="item purple" id="item-회수산탄" data-name="회수 산탄" data-price="9000" data-wp="0" data-as="10">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">회수 산탄 (9,000)<br>공속+10%</span>
-      </div>
-      <div class="item purple" id="item-볼스카야군수품" data-name="볼스카야 군수품" data-price="9500" data-wp="0" data-as="10">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">볼스카야 군수품 (9,500)<br>공속+10%</span>
-      </div>
-      <div class="item purple" id="item-무기재머" data-name="무기 재머" data-price="10000" data-wp="10" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">무기 재머 (10,000)<br>무공+10%</span>
-      </div>
-      <div class="item purple" id="item-사령관의탄창" data-name="사령관의 탄창" data-price="10000" data-wp="0" data-as="10">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">사령관의 탄창 (10,000)<br>공속+10%</span>
-      </div>
-      <div class="item purple" id="item-카두세우스연장기" data-name="카두세우스 연장기" data-price="10000" data-wp="10" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">카두세우스 연장기 (10,000)<br>무공+10%</span>
-      </div>
-      <div class="item purple" id="item-강화광가속기" data-name="강화광 가속기" data-price="11000" data-wp="10" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">강화광 가속기 (11,000)<br>무공+10%</span>
-      </div>
-      <div class="item purple" id="item-부스터제트" data-name="부스터 제트" data-price="11000" data-wp="0" data-as="20">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">부스터 제트 (11,000)<br>공속+20%</span>
-      </div>
-      <div class="item purple" id="item-성운전도" data-name="성운 전도" data-price="11000" data-wp="5" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">성운 전도 (11,000)<br>무공+5%</span>
-      </div>
-      <div class="item purple" id="item-아마리의해독제" data-name="아마리의 해독제" data-price="11000" data-wp="15" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">아마리의 해독제 (11,000)<br>무공+15% (HP<50%)</span>
-      </div>
-      <div class="item purple" id="item-엘사가제압기" data-name="엘사가 제압기" data-price="11000" data-wp="10" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">엘사가 제압기 (11,000)<br>무공+10%</span>
-      </div>
-      <div class="item purple" id="item-거미의눈" data-name="거미의 눈" data-price="14000" data-wp="25" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">거미의 눈 (14,000)<br>무공+25%</span>
-      </div>
-      <div class="item purple" id="item-종결자" data-name="종결자" data-price="14500" data-wp="20" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">종결자 (14,500)<br>무공+20%</span>
-      </div>
-
+      <!-- Weapon Items are injected via JavaScript -->
       </div>
       <div class="item-list-content item-tab-panel" role="tabpanel" data-tab-panel="tech" hidden>
-
-      <!-- Tech Items -->
-      <div class="item green" id="item-수상쩍은장관" data-name="수상쩍은 장관" data-price="1000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">수상쩍은 장관 (1,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item green" id="item-충전판갑" data-name="충전 판갑" data-price="1000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">충전 판갑 (1,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item green" id="item-파워전술" data-name="파워 전술" data-price="1000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">파워 전술 (1,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item green" id="item-승리의태도" data-name="승리의 태도" data-price="1500" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">승리의 태도 (1,500)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-맞춤형개머리판" data-name="맞춤형 개머리판" data-price="3750" data-wp="5" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">맞춤형 개머리판 (3,750)<br>무공+5%</span>
-      </div>
-      <div class="item blue" id="item-생체광오버플로" data-name="생체광 오버플로" data-price="4000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">생체광 오버플로 (4,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-손목싸개" data-name="손목 싸개" data-price="4000" data-wp="0" data-as="10">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">손목 싸개 (4,000)<br>공속+10%</span>
-      </div>
-      <div class="item blue" id="item-스카이라인나노머신" data-name="스카이라인 나노머신" data-price="4000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">스카이라인 나노머신 (4,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-쓰레기촌뭐더라" data-name="쓰레기촌 뭐더라" data-price="4000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">쓰레기촌 뭐더라 (4,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-에너지충전손목방어구" data-name="에너지 충전 손목 방어구" data-price="4000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">에너지 충전 손목 방어구 (4,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-다용도도구" data-name="다용도 도구" data-price="4500" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">다용도 도구 (4,500)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-활력증폭기" data-name="활력 증폭기" data-price="5000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">활력 증폭기 (5,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-나노콜라" data-name="나노 콜라" data-price="6000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">나노 콜라 (6,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-음파재충전" data-name="음파 재충전" data-price="9000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">음파 재충전 (9,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-3연속토미건발사" data-name="3연속 토미건 발사" data-price="9500" data-wp="0" data-as="10">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">3연속 토미건 발사 (9,500)<br>공속+10%</span>
-      </div>
-      <div class="item purple" id="item-루메리코융합기관포" data-name="루메리코 융합 기관포" data-price="10000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">루메리코 융합 기관포 (10,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-생체기술극대화" data-name="생체기술 극대화" data-price="10000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">생체기술 극대화 (10,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-초굴근" data-name="초굴근" data-price="10000" data-wp="10" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">초굴근 (10,000)<br>무공+10%</span>
-      </div>
-      <div class="item purple" id="item-촉매수정" data-name="촉매 수정" data-price="10000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">촉매 수정 (10,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-사이버베놈" data-name="사이버베놈" data-price="10500" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">사이버베놈 (10,500)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-광채눈동자" data-name="광채 눈동자" data-price="11000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">광채 눈동자 (11,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-액체질소" data-name="액체질소" data-price="11000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">액체질소 (11,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-여우의징표" data-name="여우의 징표" data-price="11000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">여우의 징표 (11,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-챔피언의도구" data-name="챔피언의 도구" data-price="14000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">챔피언의 도구 (14,000)<br>무공+0%, 공속+0%</span>
-      </div>
-
+      <!-- Tech Items are injected via JavaScript -->
       </div>
       <div class="item-list-content item-tab-panel" role="tabpanel" data-tab-panel="survival" hidden>
-
-      <!-- Survival Items -->
-      <div class="item green" id="item-러닝화" data-name="러닝화" data-price="1000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">러닝화 (1,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item green" id="item-전투식량" data-name="전투식량" data-price="1000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">전투식량 (1,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item green" id="item-전해액" data-name="전해액" data-price="1000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">전해액 (1,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item green" id="item-탄도완화" data-name="탄도 완화" data-price="1000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">탄도 완화 (1,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item green" id="item-심장박동센서" data-name="심장 박동 센서" data-price="1500" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">심장 박동 센서 (1,500)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item green" id="item-아드레날린주사" data-name="아드레날린 주사" data-price="1500" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">아드레날린 주사 (1,500)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item green" id="item-응급치료키트" data-name="응급 치료 키트" data-price="1500" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">응급 치료 키트 (1,500)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item green" id="item-장갑조끼" data-name="장갑 조끼" data-price="1500" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">장갑 조끼 (1,500)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item green" id="item-흡수장갑" data-name="흡수 장갑" data-price="1500" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">흡수 장갑 (1,500)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-강철눈" data-name="강철 눈" data-price="3750" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">강철 눈 (3,750)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-강화티타늄" data-name="강화 티타늄" data-price="3750" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">강화 티타늄 (3,750)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-비슈카르콘덴서" data-name="비슈카르 콘덴서" data-price="3750" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">비슈카르 콘덴서 (3,750)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-완충재" data-name="완충재" data-price="3750" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">완충재 (3,750)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-E생명력" data-name="E생명력" data-price="4000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">E생명력 (4,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-철갑배기구" data-name="철갑 배기구" data-price="4000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">철갑 배기구 (4,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-피의구속" data-name="피의 구속" data-price="4000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">피의 구속 (4,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item blue" id="item-성전사유압시스템" data-name="성전사 유압 시스템" data-price="4500" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-
-        <span class="item-label">성전사 유압 시스템 (4,500)<br>무공+0%, 공속+0%<br><small>조건부 활성 시 공속+5%</small></span>
-
-      </div>
-      <div class="item blue" id="item-메카Z시리즈" data-name="메카 Z 시리즈" data-price="5000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">메카 Z 시리즈 (5,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-유전학자의약병" data-name="유전학자의 약병" data-price="9000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">유전학자의 약병 (9,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-신성한개입" data-name="신성한 개입" data-price="9500" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">신성한 개입 (9,500)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-오버드라이브핵" data-name="오버드라이브 핵" data-price="9500" data-wp="10" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">오버드라이브 핵 (9,500)<br>무공+10%</span>
-      </div>
-      <div class="item purple" id="item-뤼스퉁폰빌헬름" data-name="뤼스퉁 폰 빌헬름" data-price="10000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">뤼스퉁 폰 빌헬름 (10,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-바나듐주사" data-name="바나듐 주사" data-price="10000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-
-        <span class="item-label">바나듐 주사 (10,000)<br>무공+0%, 공속+0%<br><small>조건부 활성 시 무공+10%, 공속+10%</small></span>
-
-      </div>
-      <div class="item purple" id="item-어둠의건틀릿" data-name="어둠의 건틀릿" data-price="10000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">어둠의 건틀릿 (10,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-화성의수리공" data-name="화성의 수리공" data-price="10000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">화성의 수리공 (10,000)<br>무공+0%, 공속+0%</span>
-      </div>
-      <div class="item purple" id="item-환영유입" data-name="환영 유입" data-price="10000" data-wp="10" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">환영 유입 (10,000)<br>무공+10%</span>
-      </div>
-      <div class="item purple" id="item-오군디무감소장" data-name="오군디무 감소장" data-price="11000" data-wp="0" data-as="0">
-        <div class="item-controls">
-          <label title="포함" class="chip include-chip"><input type="checkbox" class="include"><span>포함</span></label>
-          <label title="고정" class="chip pin-chip"><input type="checkbox" class="pin"><span>고정</span></label>
-        </div>
-        <span class="item-label">오군디무 감소장 (11,000)<br>무공+0%, 공속+0%</span>
+      <!-- Survival Items are injected via JavaScript -->
       </div>
     </div>
   </div>
@@ -1193,8 +674,8 @@
     const toggleScenarioBtn = document.getElementById('toggleScenario');
     const scenarioContent = document.querySelector('.scenario-content');
 
-    const includeInputs = Array.from(document.querySelectorAll('.include'));
-    const pinInputs = Array.from(document.querySelectorAll('.pin'));
+    let includeInputs = [];
+    let pinInputs = [];
     const lowHpInput = document.getElementById('chkLowHp');
     const stackRadios = document.querySelectorAll('input[name="stack"]');
     const conditionalToggle = document.getElementById('chkConditional');
@@ -1202,13 +683,157 @@
     const tabPanels = Array.from(document.querySelectorAll('.item-tab-panel'));
     const editItemsBtn = document.getElementById('editItems');
     const itemListEl = document.querySelector('.item-list');
-    const itemCards = Array.from(document.querySelectorAll('.item-list .item'));
+    let itemCards = [];
 
     const totalPriceEl = document.getElementById('totalPrice');
     const totalWPEl = document.getElementById('totalWP');
     const totalASEl = document.getElementById('totalAS');
     const healingEl = document.getElementById('healing');
     const bestComboTbody = document.getElementById('bestCombo');
+
+    const itemData = {
+      weapon: [
+        { name: '무기 기름칠', price: 1000, wp: 0, as: 5, rarity: 'green', description: '공속+5%' },
+        { name: '보정기', price: 1000, wp: 5, as: 0, rarity: 'green', description: '무공+5%' },
+        { name: '부품 시장 발사 핀', price: 3750, wp: 0, as: 10, rarity: 'blue', description: '공속+10%' },
+        { name: '고급 나노생물학', price: 4000, wp: 5, as: 10, rarity: 'blue', description: '무공+5%, 공속+10%' },
+        { name: '공중 기동기', price: 4000, wp: 5, as: 10, rarity: 'blue', description: '무공+5%, 공속+10%(고정 전용)', fixedOnly: true },
+        { name: '꽉 채운 잔', price: 4500, wp: 0, as: 5, rarity: 'blue', description: '공속+5%' },
+        { name: '차가운 냉각수', price: 5500, wp: 10, as: 0, rarity: 'blue', description: '무공+10%' },
+        { name: '탈론 개조 모듈', price: 6000, wp: 15, as: 0, rarity: 'blue', description: '무공+15%' },
+        { name: '공중 조난자', price: 9000, wp: 0, as: 10, rarity: 'purple', description: '공속+10%' },
+        { name: '코드브레이커', price: 9000, wp: 15, as: 0, rarity: 'purple', description: '무공+15%' },
+        { name: '회수 산탄', price: 9000, wp: 0, as: 10, rarity: 'purple', description: '공속+10%' },
+        { name: '볼스카야 군수품', price: 9500, wp: 0, as: 10, rarity: 'purple', description: '공속+10%' },
+        { name: '무기 재머', price: 10000, wp: 10, as: 0, rarity: 'purple', description: '무공+10%' },
+        { name: '사령관의 탄창', price: 10000, wp: 0, as: 10, rarity: 'purple', description: '공속+10%' },
+        { name: '카두세우스 연장기', price: 10000, wp: 10, as: 0, rarity: 'purple', description: '무공+10%' },
+        { name: '강화광 가속기', price: 11000, wp: 10, as: 0, rarity: 'purple', description: '무공+10%' },
+        { name: '부스터 제트', price: 11000, wp: 0, as: 20, rarity: 'purple', description: '공속+20%' },
+        { name: '성운 전도', price: 11000, wp: 5, as: 0, rarity: 'purple', description: '무공+5%' },
+        { name: '아마리의 해독제', price: 11000, wp: 15, as: 0, rarity: 'purple', description: '무공+15% (HP<50%)' },
+        { name: '엘사가 제압기', price: 11000, wp: 10, as: 0, rarity: 'purple', description: '무공+10%' },
+        { name: '거미의 눈', price: 14000, wp: 25, as: 0, rarity: 'purple', description: '무공+25%' },
+        { name: '종결자', price: 14500, wp: 20, as: 0, rarity: 'purple', description: '무공+20%' },
+      ],
+      tech: [
+        { name: '수상쩍은 장관', price: 1000, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '충전 판갑', price: 1000, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '파워 전술', price: 1000, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '승리의 태도', price: 1500, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '맞춤형 개머리판', price: 3750, wp: 5, as: 0, rarity: 'blue', description: '무공+5%' },
+        { name: '생체광 오버플로', price: 4000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '손목 싸개', price: 4000, wp: 0, as: 10, rarity: 'blue', description: '공속+10%' },
+        { name: '스카이라인 나노머신', price: 4000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '쓰레기촌 뭐더라', price: 4000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '에너지 충전 손목 방어구', price: 4000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '다용도 도구', price: 4500, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '활력 증폭기', price: 5000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '나노 콜라', price: 6000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '음파 재충전', price: 9000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '3연속 토미건 발사', price: 9500, wp: 0, as: 10, rarity: 'purple', description: '공속+10%' },
+        { name: '루메리코 융합 기관포', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '생체기술 극대화', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '초굴근', price: 10000, wp: 10, as: 0, rarity: 'purple', description: '무공+10%' },
+        { name: '촉매 수정', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '사이버베놈', price: 10500, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '광채 눈동자', price: 11000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '액체질소', price: 11000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '여우의 징표', price: 11000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '챔피언의 도구', price: 14000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+      ],
+      survival: [
+        { name: '러닝화', price: 1000, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '전투식량', price: 1000, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '전해액', price: 1000, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '탄도 완화', price: 1000, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '심장 박동 센서', price: 1500, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '아드레날린 주사', price: 1500, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '응급 치료 키트', price: 1500, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '장갑 조끼', price: 1500, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '흡수 장갑', price: 1500, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
+        { name: '강철 눈', price: 3750, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '강화 티타늄', price: 3750, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '비슈카르 콘덴서', price: 3750, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '완충재', price: 3750, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: 'E생명력', price: 4000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '철갑 배기구', price: 4000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '피의 구속', price: 4000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '성전사 유압 시스템', price: 4500, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%', note: '조건부 활성 시 공속+5%' },
+        { name: '메카 Z 시리즈', price: 5000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
+        { name: '유전학자의 약병', price: 9000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '신성한 개입', price: 9500, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '오버드라이브 핵', price: 9500, wp: 10, as: 0, rarity: 'purple', description: '무공+10%' },
+        { name: '뤼스퉁 폰 빌헬름', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '바나듐 주사', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%', note: '조건부 활성 시 무공+10%, 공속+10%' },
+        { name: '어둠의 건틀릿', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '화성의 수리공', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+        { name: '환영 유입', price: 10000, wp: 10, as: 0, rarity: 'purple', description: '무공+10%' },
+        { name: '오군디무 감소장', price: 11000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
+      ],
+    };
+
+    const slugify = (name = '') => name.replace(/\s+/g, '');
+
+    function createItemCard(item) {
+      const card = document.createElement('div');
+      const idBase = item.id || slugify(item.name);
+      card.className = `item ${item.rarity}`;
+      card.id = `item-${idBase}`;
+      card.dataset.name = item.name;
+      card.dataset.price = String(item.price);
+      card.dataset.wp = String(item.wp);
+      card.dataset.as = String(item.as);
+      if (item.fixedOnly) {
+        card.dataset.fixedOnly = 'true';
+      }
+
+      const controls = document.createElement('div');
+      controls.className = 'item-controls';
+
+      const includeLabel = document.createElement('label');
+      includeLabel.title = '포함';
+      includeLabel.className = 'chip include-chip';
+      includeLabel.innerHTML = '<input type="checkbox" class="include"><span>포함</span>';
+
+      const pinLabel = document.createElement('label');
+      pinLabel.title = '고정';
+      pinLabel.className = 'chip pin-chip';
+      pinLabel.innerHTML = '<input type="checkbox" class="pin"><span>고정</span>';
+
+      controls.append(includeLabel, pinLabel);
+
+      const label = document.createElement('span');
+      label.className = 'item-label';
+      let labelHtml = `${item.name} (${item.price})<br>${item.description}`;
+      if (item.note) {
+        labelHtml += `<br><small>${item.note}</small>`;
+      }
+      label.innerHTML = labelHtml;
+
+      card.append(controls, label);
+      return card;
+    }
+
+    function renderItems() {
+      Object.entries(itemData).forEach(([category, items]) => {
+        const panel = document.querySelector(`.item-tab-panel[data-tab-panel="${category}"]`);
+        if (!panel) return;
+        panel.innerHTML = '';
+        items.forEach(item => {
+          panel.appendChild(createItemCard(item));
+        });
+      });
+    }
+
+    function refreshItemReferences() {
+      includeInputs = Array.from(document.querySelectorAll('.include'));
+      pinInputs = Array.from(document.querySelectorAll('.pin'));
+      itemCards = Array.from(document.querySelectorAll('.item-list .item'));
+    }
+
+    renderItems();
+    refreshItemReferences();
 
     // --- 상수 정의 ---
     const baseHealing = 60;


### PR DESCRIPTION
## Summary
- 무기/기술/생존 탭의 아이템 카드를 제거하고 자바스크립트에서 정의한 데이터로 렌더링하도록 변경했습니다.
- 아이템 가격과 능력치, 조건부 설명을 데이터 테이블로 정리해 자동으로 카드가 생성되도록 구성했습니다.

## Testing
- 테스트를 실행하지 않았습니다 (정적 페이지).


------
https://chatgpt.com/codex/tasks/task_e_68d3cb74dbbc8322bc2da68b12954ec8