### PR TITLE
정리: 조건부 효과 명칭 및 반사 코팅 설명

### DIFF
--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@
         </div>
         <div class="scen-item">
           <input type="checkbox" id="chkSuperSerum">
-          <label for="chkSuperSerum">슈퍼 혈청 사용 효과</label>
+          <label for="chkSuperSerum">슈퍼 혈청</label>
         </div>
       </div>
     </div>
@@ -760,7 +760,7 @@
         { name: '전투식량', price: 1000, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
         { name: '전해액', price: 1000, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
         { name: '탄도 완화', price: 1000, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
-        { name: '반사 코팅', price: 1500, wp: 0, as: 0, rarity: 'green', description: '생명력+25. 기절/수면/방해/회복 불가 시 3초 동안 추가 생명력+75 (재사용 대기시간 20초).' },
+        { name: '반사 코팅', price: 1500, wp: 0, as: 0, rarity: 'green', description: '' },
         { name: '아드레날린 주사', price: 1500, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
         { name: '응급 치료 키트', price: 1500, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
         { name: '장갑 조끼', price: 1500, wp: 0, as: 0, rarity: 'green', description: '무공+0%, 공속+0%' },
@@ -774,13 +774,13 @@
         { name: '공기역학적 깃털', price: 4000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%'},
         { name: '천사의 레저 복장', price: 4000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%'},
         { name: '피의 구속', price: 4000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
-        { name: '성전사 유압 시스템', price: 4500, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%', note: '조건부 활성 시 공속+5%' },
+        { name: '성전사 유압 시스템', price: 4500, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%', note: '조건부 활성화 시 공속+5%' },
         { name: '메카 Z 시리즈', price: 5000, wp: 0, as: 0, rarity: 'blue', description: '무공+0%, 공속+0%' },
         { name: '유전학자의 약병', price: 9000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
         { name: '신성한 개입', price: 9500, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
         { name: '오버드라이브 핵', price: 9500, wp: 10, as: 0, rarity: 'purple', description: '무공+10%' },
         { name: '뤼스퉁 폰 빌헬름', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
-        { name: '바나듐 주사', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%', note: '조건부 활성 시 무공+10%, 공속+10%' },
+        { name: '바나듐 주사', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%', note: '조건부 활성화 시 무공+10%, 공속+10%' },
         { name: '어둠의 건틀릿', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
         { name: '화성의 수리공', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
         { name: '환영 유입', price: 10000, wp: 10, as: 0, rarity: 'purple', description: '무공+10%' },
@@ -800,7 +800,7 @@
         { name: '카네자카 부적', price: 9000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
         { name: '제트 스케이팅', price: 9500, wp: 10, as: 0, rarity: 'purple', description: '무공+10%, 공속+0%' },
         { name: '괴저 방지제', price: 10000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
-        { name: '슈퍼 혈청', price: 10000, wp: 0, as: 10, rarity: 'purple', description: '무공+0%, 공속+10%', note: '조건부 (사용 시): 무공-15%, 공속+50%' },
+        { name: '슈퍼 혈청', price: 10000, wp: 0, as: 10, rarity: 'purple', description: '무공+0%, 공속+10%', note: '조건부 활성화 시 무공-15%, 공속+50%' },
         { name: '거상 핵', price: 11000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
         { name: '재정비', price: 13000, wp: 0, as: 0, rarity: 'purple', description: '무공+0%, 공속+0%' },
       ],


### PR DESCRIPTION
## Summary
- 조건부 효과 토글에 아이템 이름만 표시되도록 정리했습니다.
- 조건부 아이템 카드의 추가 설명을 "조건부 활성화 시" 표현으로 통일했습니다.
- 반사 코팅 아이템 카드에서 불필요한 상세 설명을 제거했습니다.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9117094e883229787dc8c3f627c1d